### PR TITLE
mapping for security groups for terraform. 

### DIFF
--- a/js/mappings.js
+++ b/js/mappings.js
@@ -5677,7 +5677,10 @@ function performF2Mappings(objects) {
                     'terraformType': 'aws_security_group',
                     'options': reqParams,
                     'returnValues': {
-                        'Ref': obj.data.GroupId
+                        'Ref': obj.data.GroupId,
+                        'Terraform': {
+                            'id': obj.data.GroupId
+                        }
                     }
                 });
             } else if (obj.type == "route53.healthcheck") {


### PR DESCRIPTION
This only works if groups added in the correct order.

Not sure yet where ordering takes place and how we can fix it to work regardless of order, but avoid circular dependencies. 