### PR TITLE
Fix exponential backoff mechanism

### DIFF
--- a/js/datatables.js
+++ b/js/datatables.js
@@ -233,7 +233,7 @@ function sdkcall(svc, method, params, alert_on_errors, backoff) {
                         console.log("Too many requests, sleeping for " + backoff + "ms");
                         await new Promise(resolve => setTimeout(resolve, backoff));
                         backoff *= 2;
-                        backoff = Math.max(backoff, 120000);
+                        backoff = Math.min(backoff, 120000);
                     } else {
                         console.log("Too many requests, sleeping for 500ms");
                         await new Promise(resolve => setTimeout(resolve, 500));


### PR DESCRIPTION
`Math.max(x,120000)` for values of `x` lower than 120000 will always result in 120000. To get a backoff value with a maximum of 120000, you have to use `Math.min()`

Fixes #36