### PR TITLE
Added an option to sort resources before outputting

### DIFF
--- a/cli/main.js
+++ b/cli/main.js
@@ -73,6 +73,10 @@ async function main(opts) {
 
     b1.stop();
 
+    if (opts.sortOutput) {
+        cli_resources = cli_resources.sort((a, b) => (a.f2id > b.f2id) ? 1 : -1);
+    }
+
     if (opts.outputDebug) {
         fs.writeFile(opts.outputDebug, JSON.stringify(cli_resources, null, 4), (err) => {
             if (err) throw err;
@@ -128,6 +132,7 @@ cliargs
     .option('--output-terraform <filename>', 'filename for Terraform output')
     .option('--output-debug <filename>', 'filename for debug output (full)')
     .option('--resource-filter <value>', 'search filter for discovered resources')
+    .option('--sort-output', 'sort resources by their ID before outputting')
     .action(opts => {
         validaction = true;
         main(opts);


### PR DESCRIPTION
When using Former2 CLI ( #42 ) against a production AWS account, I found it extremely useful to have the CLI sort resources before outputting. This allows quick and valid usage with the `diff` utility.

For example: `diff cfn1.yaml cfn2.yml`

Without the sort option, `diff`ing would not be useful unless the JSON/YAML is parsed.