### PR TITLE
optimized the inner loop of main() to avoid sleeping

### DIFF
--- a/cli/main.js
+++ b/cli/main.js
@@ -62,18 +62,18 @@ async function main(opts) {
             let dtname = 'updateDatatable' + nav(section.category) + nav(section.service);
             return eval(dtname);
         })
-        .map(work => {
-            return new Promise(async resolve => {
+        .map(work =>
+            new Promise(async resolve => {
                 try {
                     await work();
-                } catch(err) {
-                    awslog.warn(util.format("updateDatatable failed: %j", err));
+                } catch (err) {
+                    awslog.warn(util.format('updateDatatable failed: %j', err));
                 } finally {
                     b1.increment();
                     resolve();
                 }
-            });
-        })
+            })
+        )
     );
 
     b1.stop();

--- a/cli/main.js
+++ b/cli/main.js
@@ -83,7 +83,7 @@ async function main(opts) {
     }
 
     if (opts.outputDebug) {
-        fs.writeFile(opts.outputDebug, JSON.stringify(cli_resources, null, 4));
+        fs.writeFileSync(opts.outputDebug, JSON.stringify(cli_resources, null, 4));
     }
 
     if (opts.outputCloudformation || opts.outputTerraform) {

--- a/cli/main.js
+++ b/cli/main.js
@@ -133,6 +133,10 @@ cliargs
     .option('--resource-filter <value>', 'search filter for discovered resources')
     .option('--sort-output', 'sort resources by their ID before outputting')
     .action(opts => {
+        // The followings are here to silence Node runtime complaining about event emitter listeners
+        // due to the number of TLS requests that suddenly go out to AWS APIs. This is harmless here
+        require('events').EventEmitter.defaultMaxListeners = 1000;
+        process.setMaxListeners(0);
         validation = true;
         main(opts);
     });


### PR DESCRIPTION
- Optimized the inner work loop of the CLI to avoid sleeping. The CLI now finishes (and fails!) faster without using timers
- Changed file writings to their sync version to make the CLI fail faster if write permission is missing (useful on Lambda)
- Used `path.join` in earlier `eval`s to be cross platform friendly (Windows does not recognize `/` for path separation)
- Allowed region to be passed through environment and fallback to `us-east-1` (N. Viriginia)
- Make main throw when all three outputs are set to false to stay consistent with the way other places in `main()` for error reporting
- Fixed a type (`validation` variable)