### PR TITLE
fix Error calling ECS.describeTaskSets.

### DIFF
--- a/js/datatables.js
+++ b/js/datatables.js
@@ -13473,7 +13473,7 @@ async function updateDatatableComputeECS() {
                                     await sdkcall("ECS", "describeTaskSets", {
                                         cluster: clusterArn,
                                         service: serviceArn,
-                                        taskSets: data.services[0].taskSets
+                                        taskSets: data.services[0].taskSets.map((taskset) => taskset.taskSetArn)
                                     }, true).then((data) => {
                                         data.taskSets.forEach(taskset => {
                                             $('#section-compute-ecs-tasksets-datatable').bootstrapTable('append', [{


### PR DESCRIPTION
Error calling ECS.describeTaskSets. Expected params.taskSets[0] to be a string

![image](https://user-images.githubusercontent.com/18655/71968072-a0cbd080-3247-11ea-963b-066172e5fa75.png)

https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeTaskSets.html

Parameter type of `taskSets` is Array of strings. The ID or full Amazon Resource Name (ARN) of task sets to describe.