### PR TITLE
Filter IAM Users and Roles by Tags

### DIFF
--- a/js/services/iam.js
+++ b/js/services/iam.js
@@ -614,13 +614,11 @@ async function updateDatatableSecurityIdentityAndComplianceIAM() {
             $('#section-securityidentityandcompliance-iam-servicelinkedroles-datatable').bootstrapTable('removeAll');
             
             await Promise.all(data.Roles.map(async (role) => {
-                await Promise.all([
-                    sdkcall("IAM", "listRoleTags", {
-                        RoleName: role.RoleName
-                    }, true).then((tags) => {
-                        role['Tags'] = tags.Tags;
-                    }),
-                ]);
+                await sdkcall("IAM", "listRoleTags", {
+                    RoleName: role.RoleName
+                }, true).then((tags) => {
+                    role['Tags'] = tags.Tags;
+                })
 
                 if (role.Path.startsWith("/aws-service-role/")) {
                     $('#section-securityidentityandcompliance-iam-servicelinkedroles-datatable').deferredBootstrapTable('append', [{


### PR DESCRIPTION
I'm using the CLI to filter all resources of interest by Tags. However, this was not possible with IAM Users and Roles. Thus, these requested changes allow one to filter and generate these resources using tags.

Example:
`node main.js generate --region us-east-1 --search-filter former2backup --output-cloudformation test.yaml`
...
```
AWSTemplateFormatVersion: "2010-09-09"
Metadata:
    Generator: "former2"
Description: ""
Resources:
    IAMUser:
        Type: "AWS::IAM::User"
        Properties:
            Path: "/"
            UserName: "..."
            Groups: 
              - "..."
            Tags: 
              - 
                Key: "DR"
                Value: "former2backup"
            ManagedPolicyArns: 
              - "..."

    IAMRole:
        Type: "AWS::IAM::Role"
        Properties:
            Path: "/"
            RoleName: "..."
            AssumeRolePolicyDocument: "..."
            MaxSessionDuration: 3600
            ManagedPolicyArns: 
              - "..."
            Description: "..."
            Tags: 
              - 
                Key: "DR"
                Value: "former2backup"

```