### PR TITLE
Fix tf output for rds_cluster maintenance window

### DIFF
--- a/js/services/rds.js
+++ b/js/services/rds.js
@@ -1074,7 +1074,7 @@ service_mapping_functions.push(function(reqParams, obj, tracked_resources){
         reqParams.cfn['PreferredBackupWindow'] = obj.data.PreferredBackupWindow;
         reqParams.tf['preferred_backup_window'] = obj.data.PreferredBackupWindow;
         reqParams.cfn['PreferredMaintenanceWindow'] = obj.data.PreferredMaintenanceWindow;
-        reqParams.tf['PreferredMaintenanceWindow'] = obj.data.PreferredMaintenanceWindow;
+        reqParams.tf['preferred_maintenance_window'] = obj.data.PreferredMaintenanceWindow;
         reqParams.cfn['ReplicationSourceIdentifier'] = obj.data.ReplicationSourceIdentifier;
         reqParams.tf['replication_source_identifier'] = obj.data.ReplicationSourceIdentifier;
         if (obj.data.VpcSecurityGroups) {


### PR DESCRIPTION
The terraform output for obj.data.PreferredMaintenanceWindow should be `preferred_maintenance_window` in the rds_cluster section.