### PR TITLE
Fix UnhandledPromiseRejectionWarning in SNS service

### DIFF
--- a/js/services/sns.js
+++ b/js/services/sns.js
@@ -173,7 +173,7 @@ async function updateDatatableApplicationIntegrationSNS() {
                                 subscriptionarn: topic.SubscriptionArn,
                                 topicarn: topic.TopicArn
                             }]);
-                        });
+                        }).catch((error) => { });
                     });
                 })
             ]);


### PR DESCRIPTION
This pull request adds a `.catch` handler to the `listSubscriptionsByTopic` SNS AWS call.

It's not clear why but there are one or often more exceptions with `null` thrown, the previous SNS call also [ignores](https://github.com/dnicolson/former2/blob/3278c3b3bc201944dff92e9066246d982b80659a/js/services/sns.js#L145) such errors.