### PR TITLE
Let qualifier be an alias or $LATEST as well.

### DIFF
--- a/js/services/lambda.js
+++ b/js/services/lambda.js
@@ -923,9 +923,8 @@ service_mapping_functions.push(function(reqParams, obj, tracked_resources){
         reqParams.cfn['MaximumEventAgeInSeconds'] = obj.data.MaximumEventAgeInSeconds;
         reqParams.cfn['MaximumRetryAttempts'] = obj.data.MaximumRetryAttempts;
         var qualifier = obj.data.FunctionArn.split(":")[7];
-        if (Number.isInteger(qualifier)) {
-            reqParams.cfn['Qualifier'] = qualifier;
-        }
+        reqParams.cfn['Qualifier'] = qualifier;
+
 
         tracked_resources.push({
             'obj': obj,


### PR DESCRIPTION
AWS::Lambda::EventInvokeConfig resources are generated without the Qualifier property if the qualifier is non-numeric. This in turn generates an error when trying to parse the generated template with the CDK:

[AWS::Lambda::EventInvokeConfig] is missing required property: qualifier.

As the documentation states, qualifiers can be:

> Version - A version number.
Alias - An alias name.
Latest - To specify the unpublished version, use $LATEST.


(See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventinvokeconfig.html#cfn-lambda-eventinvokeconfig-qualifier)

This PR allows qualifiers to of type string as well.