### PR TITLE
#185 add  'andSearch' function

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -59,7 +59,7 @@ Options:
   --output-raw-data <filename>           filename for debug output (full)
   --output-logical-id-mapping <filename> filename for logical to physical id mapping
   --cfn-deletion-policy <Delete|Retain>  add DeletionPolicy in CloudFormation output
-  --search-filter <value>                search filter for discovered resources (can be comma separated)
+  --search-filter <value>                search filter for discovered resources ('or search'can be comma separated. 'and search'can be '&' separated.)
   --services <value>                     list of services to include (can be comma separated (default: ALL))
   --exclude-services <value>             list of services to exclude (can be comma separated)
   --sort-output                          sort resources by their ID before outputting

--- a/cli/README.md
+++ b/cli/README.md
@@ -59,7 +59,7 @@ Options:
   --output-raw-data <filename>           filename for debug output (full)
   --output-logical-id-mapping <filename> filename for logical to physical id mapping
   --cfn-deletion-policy <Delete|Retain>  add DeletionPolicy in CloudFormation output
-  --search-filter <value>                search filter for discovered resources ('or search'can be comma separated. 'and search'can be '&' separated.)
+  --search-filter <value>                search filter for discovered resources ('or search' can be comma separated, 'and search' can be '&' separated.)
   --services <value>                     list of services to include (can be comma separated (default: ALL))
   --exclude-services <value>             list of services to exclude (can be comma separated)
   --sort-output                          sort resources by their ID before outputting

--- a/cli/main.js
+++ b/cli/main.js
@@ -71,6 +71,7 @@ var resource_tag_cache = {};
 const iaclangselect = "typescript";
 
 function $(selector) { return new $obj(selector) }
+const isAllIncludes = (arr, target) => arr.every(el => target.includes(el));
 $obj = function (selector) { };
 $obj.prototype.bootstrapTable = function (action, data) {
     if (action == "append") {
@@ -223,6 +224,16 @@ async function main(opts) {
                             });
                             break;
                         }
+                    }
+                }else if (opts.searchFilter.includes("&")) {
+                    const searchWords = opts.searchFilter.split("&")
+                    if (isAllIncludes(searchWord, jsonres)){
+                        output_objects.push({
+                            'id': cli_resources[i].f2id,
+                            'type': cli_resources[i].f2type,
+                            'data': cli_resources[i].f2data,
+                            'region': cli_resources[i].f2region
+                        });
                     }
                 } else {
                     if (jsonres.includes(opts.searchFilter)) {

--- a/cli/main.js
+++ b/cli/main.js
@@ -227,7 +227,7 @@ async function main(opts) {
                     }
                 }else if (opts.searchFilter.includes("&")) {
                     const searchWords = opts.searchFilter.split("&")
-                    if (isAllIncludes(searchWord, jsonres)){
+                    if (isAllIncludes(searchWords, jsonres)){
                         output_objects.push({
                             'id': cli_resources[i].f2id,
                             'type': cli_resources[i].f2type,

--- a/cli/main.js
+++ b/cli/main.js
@@ -225,9 +225,9 @@ async function main(opts) {
                             break;
                         }
                     }
-                }else if (opts.searchFilter.includes("&")) {
+                } else if (opts.searchFilter.includes("&")) {
                     const searchWords = opts.searchFilter.split("&")
-                    if (isAllIncludes(searchWords, jsonres)){
+                    if (isAllIncludes(searchWords, jsonres)) {
                         output_objects.push({
                             'id': cli_resources[i].f2id,
                             'type': cli_resources[i].f2type,


### PR DESCRIPTION
#185 
This pull request solves the problem of 185 issue.
This provides  new "search-filter" function.
If 'search-filter' option includes  '&',  cli commands provide 'and search' function.
`former2 generate --output-cloudformation "cfn.yaml" --search-filter "myapp&foo"`