### PR TITLE
changed ElastiCacheReplicationGroup.MultiAZ to MultiAZEnabled

### DIFF
--- a/js/services/elasticache.js
+++ b/js/services/elasticache.js
@@ -702,7 +702,7 @@ service_mapping_functions.push(function(reqParams, obj, tracked_resources){
         reqParams.cfn['AtRestEncryptionEnabled'] = obj.data.AtRestEncryptionEnabled;
         reqParams.tf['at_rest_encryption_enabled'] = obj.data.AtRestEncryptionEnabled;
         reqParams.cfn['KmsKeyId'] = obj.data.KmsKeyId;
-        reqParams.cfn['MultiAZ'] = (obj.data.MultiAZ == "enabled");
+        reqParams.cfn['MultiAZEnabled'] = (obj.data.MultiAZ == "enabled");
 
         /*
         TODO:


### PR DESCRIPTION
This PR fixes issue with incorrectly names CloudFront template variable.

This results in error `ElastiCacheReplicationGroup: Encountered unsupported property MultiAZ` when trying to use generated template. 

This happens because as of [AWS Docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-replicationgroup.html#cfn-elasticache-replicationgroup-multiazenabled) the property name is `MultiAZEnabled`.