### PR TITLE
Fixes for s3 mappings

### DIFF
--- a/js/services/s3.js
+++ b/js/services/s3.js
@@ -1142,7 +1142,9 @@ service_mapping_functions.push(function(reqParams, obj, tracked_resources){
                 });
             });
         }
-        reqParams.cfn['ObjectLockConfiguration'] = obj.data.ObjectLockConfiguration;
+        if (obj.data.ObjectLockConfiguration) {
+            reqParams.cfn['ObjectLockConfiguration'] = obj.data.ObjectLockConfiguration;
+        }
         if (obj.data.OwnershipControls && obj.data.OwnershipControls.Rules) {
             var ownershipcontrolsrules = [];
             obj.data.OwnershipControls.Rules.forEach(occonfig => {

--- a/js/services/s3.js
+++ b/js/services/s3.js
@@ -1157,7 +1157,6 @@ service_mapping_functions.push(function(reqParams, obj, tracked_resources){
             };
         }
 
-        reqParams.cfn['Tags'] = obj.data.Tags;
         if (obj.data.PublicAccessBlockConfiguration) {
             reqParams.cfn['PublicAccessBlockConfiguration'] = {
                 'BlockPublicAcls': obj.data.PublicAccessBlockConfiguration.BlockPublicAcls,
@@ -1165,6 +1164,9 @@ service_mapping_functions.push(function(reqParams, obj, tracked_resources){
                 'IgnorePublicAcls': obj.data.PublicAccessBlockConfiguration.IgnorePublicAcls,
                 'RestrictPublicBuckets': obj.data.PublicAccessBlockConfiguration.RestrictPublicBuckets
             };
+        }
+        if (obj.data.Tags) {
+            reqParams.cfn['Tags'] = obj.data.Tags;
         }
 
         tracked_resources.push({

--- a/js/services/s3.js
+++ b/js/services/s3.js
@@ -1157,8 +1157,15 @@ service_mapping_functions.push(function(reqParams, obj, tracked_resources){
             };
         }
 
-        reqParams.cfn['PublicAccessBlockConfiguration'] = obj.data.PublicAccessBlockConfiguration;
         reqParams.cfn['Tags'] = obj.data.Tags;
+        if (obj.data.PublicAccessBlockConfiguration) {
+            reqParams.cfn['PublicAccessBlockConfiguration'] = {
+                'BlockPublicAcls': obj.data.PublicAccessBlockConfiguration.BlockPublicAcls,
+                'BlockPublicPolicy': obj.data.PublicAccessBlockConfiguration.BlockPublicPolicy,
+                'IgnorePublicAcls': obj.data.PublicAccessBlockConfiguration.IgnorePublicAcls,
+                'RestrictPublicBuckets': obj.data.PublicAccessBlockConfiguration.RestrictPublicBuckets
+            };
+        }
 
         tracked_resources.push({
             'obj': obj,

--- a/js/services/s3.js
+++ b/js/services/s3.js
@@ -1131,18 +1131,16 @@ service_mapping_functions.push(function(reqParams, obj, tracked_resources){
             });
         }
         reqParams.cfn['ObjectLockConfiguration'] = obj.data.ObjectLockConfiguration;
-        reqParams.cfn['OwnershipControls'] = obj.data.OwnershipControls;
-        if (obj.data.OwnershipControls) {
-            reqParams.cfn['OwnershipControls'] = [];
-            obj.data.OwnershipControls.forEach(itconfig => {
-                reqParams.cfn['OwnershipControls'].push({
-                    'Id': itconfig.Id,
-                    'Prefix': (itconfig.Filter ? itconfig.Filter.Prefix : null),
-                    'Status': itconfig.Status,
-                    'TagFilters': (itconfig.Filter ? itconfig.Filter.Tag : null),
-                    'Tierings': itconfig.Tierings
+        if (obj.data.OwnershipControls && obj.data.OwnershipControls.Rules) {
+            var ownershipcontrolsrules = [];
+            obj.data.OwnershipControls.Rules.forEach(occonfig => {
+                ownershipcontrolsrules.push({
+                    'ObjectOwnership': occonfig.ObjectOwnership
                 });
             });
+            reqParams.cfn['OwnershipControls'] = {
+                'Rules': ownershipcontrolsrules
+            };
         }
 
         reqParams.cfn['PublicAccessBlockConfiguration'] = obj.data.PublicAccessBlockConfiguration;

--- a/js/services/s3.js
+++ b/js/services/s3.js
@@ -1085,6 +1085,18 @@ service_mapping_functions.push(function(reqParams, obj, tracked_resources){
                 });
             });
         }
+        if (obj.data.IntelligentTieringConfiguration) {
+            reqParams.cfn['IntelligentTieringConfiguration'] = [];
+            obj.data.IntelligentTieringConfiguration.forEach(itconfig => {
+                reqParams.cfn['IntelligentTieringConfiguration'].push({
+                    'Id': itconfig.Id,
+                    'Prefix': (itconfig.Filter ? itconfig.Filter.Prefix : null),
+                    'Status': itconfig.Status,
+                    'TagFilters': (itconfig.Filter ? itconfig.Filter.Tag : null),
+                    'Tierings': itconfig.Tierings
+                });
+            });
+        }
         if (obj.data.InventoryConfigurations && obj.data.InventoryConfigurations.InventoryConfigurationList) {
             reqParams.cfn['InventoryConfigurations'] = [];
             obj.data.InventoryConfigurations.InventoryConfigurationList.forEach(config => {


### PR DESCRIPTION
The OwnershipControls and IntelligentTieringConfiguration mappings are broken, and commit https://github.com/iann0036/former2/commit/09bb373bc92f60dccede943e191d2a4382a16cbb as mentioned in issue https://github.com/iann0036/former2/issues/317 did not address the issues with OwnershipControls properly. This pull request fixes the OwnershipControls mapping, adds back in the IntelligentTieringConfiguration mapping, and only populates the mappings for ObjectLockConfiguration, PublicAccessBlockConfiguration, and Tags if they are present in the configuration data.