### PR TITLE
Fix S3 prefix

### DIFF
--- a/js/services/s3.js
+++ b/js/services/s3.js
@@ -856,7 +856,6 @@ service_mapping_functions.push(function(reqParams, obj, tracked_resources){
                 var lifecyclerule = {
                     'AbortIncompleteMultipartUpload': rule.AbortIncompleteMultipartUpload,
                     'Id': rule.ID,
-                    'Prefix': rule.Prefix,
                     'Status': rule.Status
                 };
 
@@ -888,6 +887,10 @@ service_mapping_functions.push(function(reqParams, obj, tracked_resources){
                     }
                 }
 
+                if (rule.Filter && rule.Filter.Prefix) {
+                    lifecyclerule['Prefix'] = rule.Filter.Prefix;
+                }
+                
                 if (rule.Transitions) {
                     lifecyclerule['Transitions'] = [];
                     rule.Transitions.forEach(transition => {


### PR DESCRIPTION
If the rule scope is "Apply to all objects in the bucket" `rule.Prefix` will always be an empty string.

If the rule scope is "Limit the scope of this rule using one or more filters" the prefix will be under `Filter`, it should be saved as just `Prefix` though.