### PR TITLE
Fix issue with loading QuickSight dashboards

### DIFF
--- a/js/services/quicksight.js
+++ b/js/services/quicksight.js
@@ -354,7 +354,7 @@ async function updateDatatableAnalyticsQuickSight() {
                     data.Dashboard['AccountId'] = accountId;
 
                     await sdkcall("QuickSight", "describeDashboardPermissions", {
-                        AnalysisId: analysis.AnalysisId,
+                        DashboardId: dashboard.DashboardId,
                         AwsAccountId: accountId
                     }, false).then(permissionsdata => {
                         data.Dashboard['Permissions'] = permissionsdata.Permissions;


### PR DESCRIPTION
# Fix QuickSight Dashboard Loading Issue

## Description
This pull request addresses the issue with loading QuickSight dashboards in the Former2 tool. The problem stems from incorrect values being passed to the `describe-dashboard-permissions` method, leading to errors when retrieving created dashboards.

## Changes Made
- Corrected method parameters in the `describe-dashboard-permissions` call.
- Ensured that the `--dashboard-id` parameter is used instead of the undefined analysis id.

## Documentation Reference
- https://awscli.amazonaws.com/v2/documentation/api/latest/reference/quicksight/describe-dashboard-permissions.html

## Screenshots
![emptydashboards](https://github.com/iann0036/former2/assets/100537067/9ba6af57-e49a-4b20-922d-562b0cf1a971)
![analysis](https://github.com/iann0036/former2/assets/100537067/206cc6fe-8b69-47de-91b4-127ed4cd7303)
![quicksight](https://github.com/iann0036/former2/assets/100537067/b41c3873-6752-4673-bc57-0952764a9256)
![image](https://github.com/iann0036/former2/assets/100537067/b7312a61-9e0d-45d8-9a14-65aec0f70263)
![listdashboards](https://github.com/iann0036/former2/assets/100537067/9cbd4f24-eff7-400b-b04f-27de14ba5a76)


