### PR TITLE
Changed search-filter to regexp and new filter command to work with saved raw data

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -59,7 +59,7 @@ Options:
   --output-raw-data <filename>           filename for debug output (full)
   --output-logical-id-mapping <filename> filename for logical to physical id mapping
   --cfn-deletion-policy <Delete|Retain>  add DeletionPolicy in CloudFormation output
-  --search-filter <value>                search filter for discovered resources ('or search' can be comma separated, 'and search' can be '&' separated.)
+  --search-filter <value>                regexp filter for discovered resources to include in the output
   --services <value>                     list of services to include (can be comma separated (default: ALL))
   --exclude-services <value>             list of services to exclude (can be comma separated)
   --sort-output                          sort resources by their ID before outputting
@@ -217,11 +217,31 @@ Generate CloudFormation output all services excluding CloudWatch and KMS.
 former2 generate --output-cloudformation "cfn.yaml" --exclude-services "CloudWatch,KMS"
 ```
 
+Generate CloudFormation output for EC2 excluding instances with volumes/ENIs
+
+```
+former2 generate --output-cloudformation "cfn.yaml" --services EC2 --search-filter '"f2type":(?!"(ec2.instance|ec2.volume|ec2.networkinterface))'
+```
+
 Generates Terraform output only for the resources that contain "myapp" in Names or Tags etc.
 Filtering by whether the JSON responses of the AWS SDK calls contain a specified string.
 
 ```
 former2 generate --output-terraform "tf.hcl" --search-filter "myapp"
+```
+
+## filter
+
+The `filter` command will use saved raw data output from previous `generate` run to produce the outputs instead of queryng the cloud every time you need to change the filter.
+
+The use case which inspired this command was to produce EC2 CFN file without instances and volumes because autoscaling groups take care of launching instances.
+
+```
+former2 filter \
+  --output-cloudformation "cloudformation.yml" \
+  --input-file "debug.json" \
+  --search-filter '"f2type":(?!"(ec2.instance|elbv2.loadbalancerlistenercertificate|ec2.volume|ec2.networkinterface))' \
+  --sort-output
 ```
 
 ## Security

--- a/cli/README.md
+++ b/cli/README.md
@@ -59,7 +59,8 @@ Options:
   --output-raw-data <filename>           filename for debug output (full)
   --output-logical-id-mapping <filename> filename for logical to physical id mapping
   --cfn-deletion-policy <Delete|Retain>  add DeletionPolicy in CloudFormation output
-  --search-filter <value>                regexp filter for discovered resources to include in the output
+  --search-filter <value>                search filter for discovered resources ('or search' can be comma separated, 'and search' can be '&' separated.)
+  --regex-filter <value>                 regexp filter for discovered resources to include in the output
   --services <value>                     list of services to include (can be comma separated (default: ALL))
   --exclude-services <value>             list of services to exclude (can be comma separated)
   --sort-output                          sort resources by their ID before outputting
@@ -217,17 +218,17 @@ Generate CloudFormation output all services excluding CloudWatch and KMS.
 former2 generate --output-cloudformation "cfn.yaml" --exclude-services "CloudWatch,KMS"
 ```
 
-Generate CloudFormation output for EC2 excluding instances with volumes/ENIs
-
-```
-former2 generate --output-cloudformation "cfn.yaml" --services EC2 --search-filter '"f2type":(?!"(ec2.instance|ec2.volume|ec2.networkinterface))'
-```
-
 Generates Terraform output only for the resources that contain "myapp" in Names or Tags etc.
 Filtering by whether the JSON responses of the AWS SDK calls contain a specified string.
 
 ```
 former2 generate --output-terraform "tf.hcl" --search-filter "myapp"
+```
+
+Generate CloudFormation output for EC2 excluding instances with volumes/ENIs
+
+```
+former2 generate --output-cloudformation "cfn.yaml" --services EC2 --regex-filter '"f2type":(?!"(ec2.instance|ec2.volume|ec2.networkinterface))'
 ```
 
 ## filter
@@ -240,7 +241,7 @@ The use case which inspired this command was to produce EC2 CFN file without ins
 former2 filter \
   --output-cloudformation "cloudformation.yml" \
   --input-file "debug.json" \
-  --search-filter '"f2type":(?!"(ec2.instance|elbv2.loadbalancerlistenercertificate|ec2.volume|ec2.networkinterface))' \
+  --regex-filter '"f2type":(?!"(ec2.instance|elbv2.loadbalancerlistenercertificate|ec2.volume|ec2.networkinterface))' \
   --sort-output
 ```
 

--- a/cli/main.js
+++ b/cli/main.js
@@ -98,7 +98,7 @@ var resource_tag_cache = {};
 const iaclangselect = "typescript";
 
 function $(selector) { return new $obj(selector) }
-const isAllIncludes = (arr, target) => arr.every(el => target.includes(el));
+const isAllIncludes = (arr, target) => arr.every(el => (el[0] == "~" ? !target.includes(el.substr(1)) : target.includes(el)));
 $obj = function (selector) { };
 $obj.prototype.bootstrapTable = function (action, data) {
     if (action == "append") {
@@ -247,7 +247,7 @@ async function main(opts) {
                 var jsonres = JSON.stringify(cli_resources[i]);
                 if (opts.searchFilter.includes(",")) {
                     for (var searchterm of opts.searchFilter.split(",")) {
-                        if (jsonres.includes(searchterm)) {
+                        if (isAllIncludes([searchterm], jsonres)) {                        
                             output_objects.push({
                                 'id': cli_resources[i].f2id,
                                 'type': cli_resources[i].f2type,
@@ -268,7 +268,7 @@ async function main(opts) {
                         });
                     }
                 } else {
-                    if (jsonres.includes(opts.searchFilter)) {
+                    if (isAllIncludes([opts.searchFilter], jsonres)) {
                         output_objects.push({
                             'id': cli_resources[i].f2id,
                             'type': cli_resources[i].f2type,


### PR DESCRIPTION
Hi,

Using regexp for filtering what to save can be more flexible in what to keep, in my case i need to save CFN as backups but do not need resources which are launch by Autoscaling groups, for example.

Playing around also took a lot of scans so i added new filter command to experiment with filters using local raw data file.

Also loading region from .aws/credentials like AWS CLI is added as well

Thank you