### PR TITLE
docker-compose: remove version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   former2:
     image: nginx:stable-alpine


### PR DESCRIPTION
```
$ docker compose version
Docker Compose version v2.36.0-desktop.1

$ docker compose up -d
WARN[0000] /path/to/former2/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

When I run `docker compose up -d`, I get the above error.
Therefore, I removed the `version` from `docker-compose.yml`.