### PR TITLE
Add ap-southeast-7 region support

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,6 +158,7 @@
                                         <a class="dropdown-item region-item" data-region="ap-southeast-2">Asia Pacific (Sydney)</a>
                                         <a class="dropdown-item region-item" data-region="ap-southeast-3">Asia Pacific (Jakarta)</a>
                                         <a class="dropdown-item region-item" data-region="ap-southeast-4">Asia Pacific (Melbourne)</a>
+                                        <a class="dropdown-item region-item" data-region="ap-southeast-7">Asia Pacific (Thailand)</a>
                                         <a class="dropdown-item region-item" data-region="ap-northeast-1">Asia Pacific (Tokyo)</a>
                                         <a class="dropdown-item region-item" data-region="ca-central-1">Canada (Central)</a>
                                         <a class="dropdown-item region-item" data-region="ca-west-1">Canada West (Calgary)</a>

--- a/js/app.js
+++ b/js/app.js
@@ -970,6 +970,7 @@ $(document).ready(function(){
         "ap-southeast-2": "Asia Pacific (Sydney)",
         "ap-southeast-3": "Asia Pacific (Jakarta)",
         "ap-southeast-4": "Asia Pacific (Melbourne)",
+        "ap-southeast-7": "Asia Pacific (Thailand)",
         "ap-northeast-1": "Asia Pacific (Tokyo)",
         "ca-central-1": "Canada (Central)",
         "ca-west-1": "Canada West (Calgary)",


### PR DESCRIPTION
Hi there!

First of all, thank you for creating Former2! I was looking for a way to export my AWS resources, and Former2 has been incredibly helpful.

While trying it out, I noticed that the new AWS Asia Pacific (Thailand) region, `ap-southeast-7`, was not available yet. I decided to try adding support for it locally, and it seems to work well, so I thought I’d open a pull request in case this would be useful for the project.

This PR adds support for the Asia Pacific (Thailand) region in both the UI and the internal region mapping.

**Changes included:**

* Added a new dropdown option for **Asia Pacific (Thailand)** with the region code `ap-southeast-7` in `index.html`.
* Updated the region mapping in `js/app.js` to include `ap-southeast-7` with the label **Asia Pacific (Thailand)**.

This is my first time opening a pull request, so please let me know if there’s anything I should adjust or improve. Happy to make any changes needed!